### PR TITLE
Footstep: Add toncoin to trust wallet assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The list of the TON Footsteps represented in the GitHub [issues](https://github.
 ### Hall of Fame
 | Name | Task | Link |
 |------|------|------|
+| [Vadim Volodin](https://github.com/PolyProgrammist/) | Add toncoin to trust wallet assets | [Issue] (https://github.com/ton-society/ton-footsteps/issues/56)     |
 | [Revuza](https://github.com/LevZed) & [Gusarich](https://github.com/Gusarich)     | Examples: How to recieve payments in a Telegram bot  | [Issue](https://github.com/ton-society/ton-footsteps/issues/8)     |
 | [Dan Volkov](https://github.com/dvlkv) | VS Code Extension for FunC | [Issue](https://github.com/ton-society/ton-footsteps/issues/18) |
 | [Oleg Baranov](https://github.com/xssnick) | Soulbound NFT's | [Issue](https://github.com/ton-society/ton-footsteps/issues/23) |


### PR DESCRIPTION
Merged prs: 
https://github.com/trustwallet/assets/pull/23209
https://github.com/trustwallet/assets/pull/22828
https://github.com/trustwallet/assets/pull/22801
Footstep: https://github.com/ton-society/ton-footsteps/issues/56
Toncoin address: EQDk0rRqwtKw34r0fecUO6YotwKfMPU9XIxwrfjOfX9BIUx_
Results achieved: updated information about toncoin in trust wallet assets
