### PR TITLE
Footstep: Add toncoin to trust wallet core

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The list of the TON Footsteps represented in the GitHub [issues](https://github.
 | [ProgramCrafter](https://github.com/ProgramCrafter) | Articles: TVM assembly, Fift and the difference | [Issue](https://github.com/ton-society/ton-footsteps/issues/110) |
 | [Gusarich](https://github.com/Gusarich) | "Message Delivery Guarantees" Article, improvements and fixes in docs | [Issue](https://github.com/ton-society/ton-footsteps/issues/112) |
 | [Slava](https://github.com/delovoyhomie) | Telegram Bot for the TON Developer Community | [Issue](https://github.com/ton-society/ton-footsteps/issues/116) |
+| [Vadim Volodin](https://github.com/PolyProgrammist/), [Vyacheslav Bushev](https://github.com/stspbu) | Add toncoin to trust wallet core | [Issue](https://github.com/ton-society/ton-footsteps/issues/81) |
 
 ### The TON Footsteps committee
 * [tonkongz](https://github.com/tonkongz)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The list of the TON Footsteps represented in the GitHub [issues](https://github.
 | [ProgramCrafter](https://github.com/ProgramCrafter) | Articles: TVM assembly, Fift and the difference | [Issue](https://github.com/ton-society/ton-footsteps/issues/110) |
 | [Gusarich](https://github.com/Gusarich) | "Message Delivery Guarantees" Article, improvements and fixes in docs | [Issue](https://github.com/ton-society/ton-footsteps/issues/112) |
 | [Slava](https://github.com/delovoyhomie) | Telegram Bot for the TON Developer Community | [Issue](https://github.com/ton-society/ton-footsteps/issues/116) |
-| [Vadim Volodin](https://github.com/PolyProgrammist/), [Vyacheslav Bushev](https://github.com/stspbu) | Add toncoin to trust wallet core | [Issue](https://github.com/ton-society/ton-footsteps/issues/81) |
+| [Vadim Volodin](https://github.com/PolyProgrammist/), [Viacheslav Bushev](https://github.com/stspbu) | Add toncoin to trust wallet core | [Issue](https://github.com/ton-society/ton-footsteps/issues/81) |
 
 ### The TON Footsteps committee
 * [tonkongz](https://github.com/tonkongz)


### PR DESCRIPTION
Code for trust wallet core:
https://github.com/trustwallet/wallet-core/tree/master/src/TheOpenNetwork

Footstep: https://github.com/ton-society/ton-footsteps/issues/81

Results achieved: 
Implemented TON blockchain in Trust Wallet Core

wallet for ton coins: EQDk0rRqwtKw34r0fecUO6YotwKfMPU9XIxwrfjOfX9BIUx_
wallet for sbt nft: EQCBA764QkuNJ6__lo1qagfHsa511ohsu8dLW8roFE-jjF-K