### PR TITLE
Development TON Connect 2.0 in MyTonWallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The list of the TON Footsteps represented in the GitHub [issues](https://github.
 | [Gusarich](https://github.com/Gusarich) | Article: Random number generation in smart contracts | [Issue](https://github.com/ton-society/ton-footsteps/issues/114) |
 | [Nikita Kuznetsov](https://github.com/KuznetsovNikita) | Development TON Connect 2.0 in OpenMask | [Issue](https://github.com/ton-society/ton-footsteps/issues/107) |
 | [AlexG](https://github.com/reveloper) | TACT lang documentation | [Issue](https://github.com/ton-society/ton-footsteps/issues/105)|
+| [mytonwalletorg](https://github.com/mytonwalletorg) | Development TON Connect 2.0 in MyTonWallet | [Issue](https://github.com/ton-society/ton-footsteps/issues/149) |
 
 
 ### The TON Footsteps committee


### PR DESCRIPTION
Closes #149 

Open-source commits: https://github.com/mytonwalletorg/mytonwallet/commit/0f353d5b34c90326f8e9220d62df71fdc80c47a8, https://github.com/mytonwalletorg/mytonwallet/commit/964d5f7b174f46fc021e6b200ae5bc3d5ed23423, https://github.com/mytonwalletorg/mytonwallet/commit/4fb3031190f3861ece8ce8fa574d3f6b39ef1422

The feature is available on https://ton.vote, https://tegro.money, https://getgems.io, https://dedust.io, etc.

The contribution wallet address is in the official repo [README](https://github.com/mytonwalletorg/mytonwallet#support-us).