### PR TITLE
Remove the requirement to open pull requests to the Hall of Fame

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ The list of the TON Footsteps represented in the GitHub [issues](https://github.
 1. Find a suitable task from the [list](https://github.com/ton-society/ton-footsteps/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved) of the approved issues
 2. Propose your plan or just ask to assign issue to yourself
 3. Finish the task and verify that all task deliverables are completed
-4. Open a pull request. Name it using the name of the task and put your name in the [Hall of Fame](https://github.com/ton-society/ton-footsteps#hall-of-fame)
-5. Leave a comment to link the pull request to the issue. For example: `PR for #3`
-6. Leave a comment with information about your ton wallet address and results achieved
-7. Wait for the committee to review your pull request
+4. Leave a comment with information about your TON wallet address and results achieved
+5. Wait for the committee to review your work
 
 ### Hall of Fame
 | Name | Task | Link |


### PR DESCRIPTION
At the moment, those who complete Footsteps have to open Pull Requests after each completed work.
This may not be an obvious point for beginners, which scares off potential contributors.
And those contributors who have never worked with Github (for example, if the Footstep is not about development) will not be able to open PR correctly at all.

I propose to transfer the duty of adding users to the Hall of Fame from the users themselves to the committee.
TON wallet address for rewards may be sent in comments of the Footstep issue.